### PR TITLE
feat: add lyric writing web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# dalszovegiro
+# Dalszövegíró
+
+Egyszerű webes alkalmazás dalszövegek írásához.
+
+## Funkciók
+- Komponensek hozzáadása: Intro, Verze, Refrén, Bridge, Outro
+- Verzék automatikus számozása (Verze 1, Verze 2, ...)
+- Szerkesztés, törlés, mentés komponensenként
+- Drag & drop sorrendezés
+- Export DOCX és PDF formátumban
+- Helyi tárolás, hogy később is folytatható legyen a munka
+- Több projekt kezelése
+
+## Használat
+Nyisd meg az `index.html` fájlt egy böngészőben, és kezdheted is a dalszöveg írását.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,188 @@
+// Simple lyric writing app with component versioning and project storage
+
+let projects = JSON.parse(localStorage.getItem('lyricProjects')) || {};
+let currentProject = null;
+let editingIndex = null;
+
+function saveProjects() {
+  localStorage.setItem('lyricProjects', JSON.stringify(projects));
+}
+
+function componentDisplayName(type, version) {
+  switch (type) {
+    case 'intro':
+      return 'Intro';
+    case 'verse':
+      return `Verze ${version}`;
+    case 'chorus':
+      return 'Refrén';
+    case 'bridge':
+      return 'Bridge';
+    case 'outro':
+      return 'Outro';
+    default:
+      return type;
+  }
+}
+
+function renderProjectOptions() {
+  const select = document.getElementById('project-select');
+  select.innerHTML = '';
+  Object.keys(projects).forEach((name) => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    if (name === currentProject) opt.selected = true;
+    select.appendChild(opt);
+  });
+}
+
+function loadProject(name) {
+  currentProject = name;
+  renderProjectOptions();
+  renderLyricsList();
+}
+
+function init() {
+  if (Object.keys(projects).length === 0) {
+    projects['Alap projekt'] = [];
+  }
+  currentProject = Object.keys(projects)[0];
+  renderProjectOptions();
+  renderLyricsList();
+}
+
+document.getElementById('project-select').addEventListener('change', (e) => {
+  loadProject(e.target.value);
+});
+
+document.getElementById('new-project').addEventListener('click', () => {
+  const name = prompt('Projekt neve?');
+  if (name && !projects[name]) {
+    projects[name] = [];
+    saveProjects();
+    loadProject(name);
+  }
+});
+
+document.getElementById('add-btn').addEventListener('click', () => {
+  const type = document.getElementById('component-type').value;
+  let version = null;
+  if (type === 'verse') {
+    const verses = projects[currentProject].filter((c) => c.type === 'verse');
+    version = verses.length + 1;
+  }
+  openEditor({ type, version, text: '' }, null);
+});
+
+function openEditor(component, index) {
+  editingIndex = index;
+  const editor = document.getElementById('editor');
+  document.getElementById('editor-text').value = component.text || '';
+  document.getElementById('editor-title').textContent = componentDisplayName(
+    component.type,
+    component.version
+  );
+  editor.dataset.type = component.type;
+  if (component.version) editor.dataset.version = component.version;
+  else delete editor.dataset.version;
+  editor.classList.remove('hidden');
+}
+
+document.getElementById('save-btn').addEventListener('click', () => {
+  const editor = document.getElementById('editor');
+  const type = editor.dataset.type;
+  const version = editor.dataset.version
+    ? parseInt(editor.dataset.version, 10)
+    : null;
+  const text = document.getElementById('editor-text').value;
+
+  if (editingIndex !== null) {
+    const comp = projects[currentProject][editingIndex];
+    comp.text = text;
+  } else {
+    const comp = { type, text };
+    if (version) comp.version = version;
+    projects[currentProject].push(comp);
+  }
+
+  saveProjects();
+  editor.classList.add('hidden');
+  renderLyricsList();
+});
+
+document.getElementById('delete-btn').addEventListener('click', () => {
+  if (editingIndex !== null) {
+    projects[currentProject].splice(editingIndex, 1);
+    saveProjects();
+    renderLyricsList();
+  }
+  document.getElementById('editor').classList.add('hidden');
+});
+
+document.getElementById('cancel-btn').addEventListener('click', () => {
+  document.getElementById('editor').classList.add('hidden');
+});
+
+function renderLyricsList() {
+  const ul = document.getElementById('lyrics-list');
+  ul.innerHTML = '';
+  projects[currentProject].forEach((comp, index) => {
+    const li = document.createElement('li');
+    li.setAttribute('data-index', index);
+
+    const header = document.createElement('strong');
+    header.textContent = componentDisplayName(comp.type, comp.version);
+    li.appendChild(header);
+
+    const pre = document.createElement('pre');
+    pre.textContent = comp.text;
+    li.appendChild(pre);
+
+    const editBtn = document.createElement('button');
+    editBtn.textContent = 'Szerkeszt';
+    editBtn.addEventListener('click', () => openEditor(comp, index));
+    li.appendChild(editBtn);
+
+    ul.appendChild(li);
+  });
+
+  Sortable.create(ul, {
+    animation: 150,
+    onEnd: (evt) => {
+      const arr = projects[currentProject];
+      const [moved] = arr.splice(evt.oldIndex, 1);
+      arr.splice(evt.newIndex, 0, moved);
+      saveProjects();
+      renderLyricsList();
+    },
+  });
+}
+
+function getFullText() {
+  return projects[currentProject]
+    .map((c) => `${componentDisplayName(c.type, c.version)}\n${c.text}`)
+    .join('\n\n');
+}
+
+document
+  .getElementById('export-docx')
+  .addEventListener('click', async () => {
+    const { Document, Packer, Paragraph } = window.docx;
+    const doc = new Document();
+    const lines = getFullText().split('\n');
+    lines.forEach((line) => doc.addParagraph(new Paragraph(line)));
+    const blob = await Packer.toBlob(doc);
+    saveAs(blob, `${currentProject}.docx`);
+  });
+
+document.getElementById('export-pdf').addEventListener('click', () => {
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF();
+  const text = getFullText();
+  const lines = doc.splitTextToSize(text, 180);
+  doc.text(lines, 10, 10);
+  doc.save(`${currentProject}.pdf`);
+});
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="hu">
+<head>
+  <meta charset="UTF-8" />
+  <title>Dalszövegíró</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/FileSaver.js/2.0.5/FileSaver.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://unpkg.com/docx@8.3.2/build/index.js"></script>
+</head>
+<body>
+  <header>
+    <select id="project-select"></select>
+    <button id="new-project">Új projekt</button>
+  </header>
+
+  <section id="add-component">
+    <select id="component-type">
+      <option value="intro">Intro</option>
+      <option value="verse">Verze</option>
+      <option value="chorus">Refrén</option>
+      <option value="bridge">Bridge</option>
+      <option value="outro">Outro</option>
+    </select>
+    <button id="add-btn">Hozzáadás</button>
+  </section>
+
+  <section id="editor" class="hidden">
+    <h2 id="editor-title"></h2>
+    <textarea id="editor-text"></textarea>
+    <div class="editor-buttons">
+      <button id="save-btn">Mentés</button>
+      <button id="delete-btn">Törlés</button>
+      <button id="cancel-btn">Mégse</button>
+    </div>
+  </section>
+
+  <section id="lyrics">
+    <h2>Teljes dalszöveg</h2>
+    <ul id="lyrics-list"></ul>
+  </section>
+
+  <section id="export">
+    <button id="export-docx">Export DOCX</button>
+    <button id="export-pdf">Export PDF</button>
+  </section>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,30 @@
+body {
+  font-family: sans-serif;
+  margin: 20px;
+}
+header, #add-component, #export {
+  margin-bottom: 20px;
+}
+#editor textarea {
+  width: 100%;
+  height: 150px;
+}
+.hidden {
+  display: none;
+}
+#lyrics-list {
+  list-style: none;
+  padding: 0;
+}
+#lyrics-list li {
+  border: 1px solid #ccc;
+  padding: 10px;
+  margin-bottom: 5px;
+  background: #f9f9f9;
+}
+#lyrics-list li.dragging {
+  opacity: 0.5;
+}
+.editor-buttons button {
+  margin-right: 10px;
+}


### PR DESCRIPTION
## Summary
- add browser-based lyric editor with component selection and versioned verses
- enable drag-and-drop ordering, DOCX/PDF export, and local project storage
- document usage in README

## Testing
- `node --check app.js`
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b429f666a083219c45ce9df64a2664